### PR TITLE
Fix(get_market_data): maxQty and minNotional

### DIFF
--- a/Examples/AUD_config/config.json
+++ b/Examples/AUD_config/config.json
@@ -13,6 +13,7 @@
         {
             "coin":"BTC",
             "fiat":"AUD",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":0,
             "trade_enable":true,
@@ -27,6 +28,7 @@
         {
             "coin":"ETH",
             "fiat":"AUD",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":0,
             "trade_enable":true,
@@ -41,6 +43,7 @@
         {
             "coin":"BNB",
             "fiat":"AUD",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":0,
             "trade_enable":true,
@@ -55,6 +58,7 @@
         {
             "coin":"SOL",
             "fiat":"AUD",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":20,
             "trade_enable":true,
@@ -69,6 +73,7 @@
         {
             "coin":"AVAX",
             "fiat":"AUD",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":20,
             "trade_enable":true,
@@ -83,6 +88,7 @@
         {
             "coin":"LINK",
             "fiat":"AUD",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":20,
             "trade_enable":true,
@@ -97,6 +103,7 @@
         {
             "coin":"AXS",
             "fiat":"AUD",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":20,
             "trade_enable":true,
@@ -111,6 +118,7 @@
         {
             "coin":"APE",
             "fiat":"AUD",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":20,
             "trade_enable":true,
@@ -125,6 +133,7 @@
         {
             "coin":"DOT",
             "fiat":"AUD",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":20,
             "trade_enable":true,
@@ -139,6 +148,7 @@
         {
             "coin":"MATIC",
             "fiat":"AUD",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":30,
             "trade_enable":true,
@@ -153,6 +163,7 @@
         {
             "coin":"SAND",
             "fiat":"AUD",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":30,
             "trade_enable":true,
@@ -167,6 +178,7 @@
         {
             "coin":"ADA",
             "fiat":"AUD",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":30,
             "trade_enable":true,

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ This is what a basic default config.json file looks like;
         {
             "coin":"BTC",
             "fiat":"USDT",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":0,
             "trade_enable":true,
@@ -101,6 +102,7 @@ This is what a basic default config.json file looks like;
         {
             "coin":"ETH",
             "fiat":"USDT",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":0,
             "trade_enable":true,
@@ -115,6 +117,7 @@ This is what a basic default config.json file looks like;
         {
             "coin":"BNB",
             "fiat":"USDT",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":0,
             "trade_enable":true,
@@ -145,6 +148,7 @@ This is what a basic default config.json file looks like;
 {
     "coin":"BTC",
     "fiat":"USDT",
+    "minNotional":5,
     "coin_hold_amount":0,
     "fiat_hold_amount":0,
     "trade_enable":true,
@@ -160,6 +164,8 @@ This is what a basic default config.json file looks like;
 **coin** Sets which cyrpto currency we wish to buy and sell.
 
 **fiat** Sets what currency we are using to buy and sell the cyrpto currency with. This could also be another cyrpto currency.
+
+**minNotional** Sets the minimum trade size in fiat currency. Binance does not allow smaller trades.
 
 **coin_hold_amount & fiat_hold_amount** Sets how much of a currency you wish to hold. These values are subtracted from your wallets free holding balance before determining if a buy or sell action is possible. Note if set to 0 the bot will use all available assets when making trades. Also note that this hold amount is only for this trading pair and not other Trading pairs.
 

--- a/config.json
+++ b/config.json
@@ -13,6 +13,7 @@
         {
             "coin":"BTC",
             "fiat":"USDT",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":0,
             "trade_enable":true,
@@ -27,6 +28,7 @@
         {
             "coin":"ETH",
             "fiat":"USDT",
+            "minNotional":5,
             "coin_hold_amount":0,
             "fiat_hold_amount":0,
             "trade_enable":true,

--- a/traderbot.py
+++ b/traderbot.py
@@ -282,8 +282,9 @@ while True:
                 coin_info = client.get_symbol_info(symbol)
                 sell_dec_place=check_decimals(coin_info['filters'][1]['stepSize'])
                 buy_dec_place=check_decimals(coin_info['filters'][0]['tickSize'])
-                coin_maxQty=coin_info['filters'][4]['maxQty']
-                min_amount=coin_info['filters'][2]['minNotional']
+                #coin_maxQty=coin_info['filters'][4]['maxQty']
+                #min_amount=coin_info['filters'][2]['minNotional']
+                min_amount=tp['minNotional']
                 fiat_available_amount=float(fiat_balance['free'])-tp['fiat_hold_amount']
                 coin_available_amount=float(coin_balance['free'])-tp['coin_hold_amount']
 
@@ -419,8 +420,8 @@ while True:
                                 if qty>(coin_available_amount):
                                     qty=float(min_amount)/price # Use minimum trade amount
 
-                                if qty>float(coin_maxQty):
-                                    qty=float(coin_maxQty) # Use Max Qty if exceeded
+                                #if qty>float(coin_maxQty):
+                                #    qty=float(coin_maxQty) # Use Max Qty if exceeded
 
                                 if qty<float(min_amount)/price:
                                     qty=float(min_amount)/price # Use minimum trade amount


### PR DESCRIPTION
Fix(get_market_data): maxQty and minNotional are not retrieved from BinanceAPI(get_symbol_info) any more.

Fixes https://github.com/idiydownunder/binance-trader-bot/issues/1